### PR TITLE
Change alert level for no metrics

### DIFF
--- a/lib/logstash/inputs/cloudwatch.rb
+++ b/lib/logstash/inputs/cloudwatch.rb
@@ -151,7 +151,7 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
 
       @logger.info('Polling CloudWatch API')
 
-      raise 'No metrics to query' unless metrics_for(@namespace).count > 0
+      warn 'WARNING: No metrics to query for #{@namespace} ' unless metrics_for(@namespace).count > 0
 
       # For every metric
       metrics_for(@namespace).each do |metric|

--- a/lib/logstash/inputs/cloudwatch.rb
+++ b/lib/logstash/inputs/cloudwatch.rb
@@ -151,7 +151,7 @@ class LogStash::Inputs::CloudWatch < LogStash::Inputs::Base
 
       @logger.info('Polling CloudWatch API')
 
-      warn 'WARNING: No metrics to query for #{@namespace} ' unless metrics_for(@namespace).count > 0
+      warn "WARNING: No metrics to query for #{@namespace}" unless metrics_for(@namespace).count > 0
 
       # For every metric
       metrics_for(@namespace).each do |metric|


### PR DESCRIPTION
When tracking a cloudwatch metric, the metric might not always have data but you still want to capture that data in the event of something hapenning in the system.
An example of this is the HTTPCode_ELB_5XX metric: you might not have any 5xx erros, but you want to know when they happen.
Currently, if this is the case and there is no captured metrics yet, the metric validation fails due to raise being used.
Considering that a metric not being present isn't a system error, but in the worst case a consiguration issue, I believe that using warn is the best option here, since it allows the system to continue to process the remaining valid metrics.